### PR TITLE
Better error when UnicodeData.txt cannot be downloaded

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -83,6 +83,7 @@ fu! unicode#Download(force) "{{{2
             endif
             bw
         else
+            call s:WarningMsg("NetRw not loaded; cannot download file")
             call s:WarningMsg("Please download " . s:unicode_URL)
             call s:WarningMsg("and save it as " . s:UniFile)
             call s:WarningMsg("Quitting")
@@ -255,15 +256,17 @@ fu! unicode#GetUniChar(...) "{{{2
     finally
         let start      = 1
         let s:output_width=1
-        if lang !=# 'C'
+        if exists('lang') && lang !=# 'C'
             exe "sil lang mess" lang
         endif
         for val in msg
             let list = matchlist(val, '^\(' . "'[^']*'". '\)\(.*\)')
-            call <sid>ScreenOutput(list[1], list[2])
-            " force linebreak
-            let s:output_width=&columns
-            let start = 0
+            if len(list) > 3
+                call <sid>ScreenOutput(list[1], list[2])
+                " force linebreak
+                let s:output_width=&columns
+                let start = 0
+            endif
         endfor
     endtry
 endfun


### PR DESCRIPTION
For the longest of time downloading `UnicodeData.txt` has failed with the follow
message:

	UnicodePlugin: File /home/martin/.vim/pack/plugins/start/unicode.vim/autoload/unicode/UnicodeData.txt does not exist or is zero.
	UnicodePlugin: Let's see, if we can download it.
	UnicodePlugin: If this doesn't work, you should download
	UnicodePlugin: http://www.unicode.org/Public/UNIDATA/UnicodeData.txt and save it as /home/martin/.vim/pack/plugins/start/unicode.vim/autoload/unicode/UnicodeData.txt
	UnicodePlugin: Please download http://www.unicode.org/Public/UNIDATA/UnicodeData.txt
	UnicodePlugin: and save it as /home/martin/.vim/pack/plugins/start/unicode.vim/autoload/unicode/UnicodeData.txt
	UnicodePlugin: Quitting
	Error detected while processing function unicode#GetUniChar:
	line   98:
	E121: Undefined variable: lang
	E15: Invalid expression: lang !=# 'C'

I finally looked into it, and turned out there were two problems:

1. I disabled NetRw, and unicode.vim only tries to download the file with NetRw.
   I suppose a `curl` and/or `wget` fallback could be added as well? For now I
   just clarified the error message.

2. The `lang` error is because it's not defined yet in the `try` block, but is
   referenced in the `finally` block.