### PR TITLE
added check for if s:UniDict is defined before use

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -830,6 +830,9 @@ fu! <sid>UnicodeWriteCache(data, ind) "{{{2
 endfu
 fu! <sid>GetUnicodeName(dec) "{{{2
     " returns Unicodename for decimal value
+    if !exists("s:UniDict")
+        let s:UniDict=<sid>UnicodeDict()
+    endif
     let name = get(s:UniDict, a:dec, '')
     if !empty(name)
         return name


### PR DESCRIPTION
in GetUnicodeName function. found this bug when calling
unicode#UnicodeName function before any other use of the plugin, hence
the variable was undefined and threw an error.