### PR TITLE
Disable mappings & Ask user & cache and data directory & Disable cache

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -102,7 +102,11 @@ fu! unicode#Download(force) abort "{{{2
         call s:WarningMsg("Let's see, if we can download it.")
         call s:WarningMsg("If this doesn't work, you should download ")
         call s:WarningMsg(s:unicode_URL . " and save it as " . s:UniFile)
-        sleep 5
+        let choice = confirm("Download " . s:unicode_URL . " now?", "&Yes\n&No", 1, "Question")
+        if choice ==# 0 || choice ==# 2
+            call s:WarningMsg("Not downloading file. You can retry by executing :UnicodeDownload")
+            return 0
+        endif
         " remove cache file
         " (will be re-created later)
         if filereadable(s:directory. '/UnicodeData.vim')

--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -11,8 +11,23 @@
 " initialize Variables {{{1
 let s:unicode_URL  = get(g:, 'Unicode_URL',
         \ 'http://www.unicode.org/Public/UNIDATA/UnicodeData.txt')
-let s:directory    = expand("<sfile>:p:h")."/unicode"
-let s:UniFile      = s:directory . '/UnicodeData.txt'
+if has("nvim")
+    " default: ~/.local/share/nvim/site/unicode/
+    let s:data_directory =
+        \ get(g:, 'Unicode_data_directory', stdpath('data') . '/site/unicode')
+    " default: ~/.cache/nvim/unicode/UnicodeData.vim
+    let s:cache_directory =
+        \ get(g:, 'Unicode_cache_directory', stdpath('cache') . '/unicode')
+else
+    let s:autoload_directory = expand("<sfile>:p:h")."/unicode"
+    let s:data_directory =
+        \ get(g:, 'Unicode_data_directory', s:autoload_directory)
+    let s:cache_directory =
+        \ get(g:, 'Unicode_cache_directory', s:autoload_directory)
+endif
+let s:data_file = s:data_directory . '/UnicodeData.txt'
+let s:data_cache_file = s:cache_directory . '/UnicodeData.vim'
+let s:table_cache_file = s:cache_directory . '/UnicodeTable.txt'
 
 " HTML entitities {{{2
 let s:html = unicode#html#get_html_entities()
@@ -93,15 +108,15 @@ fu! unicode#Regex(val) abort "{{{2
     return val
 endfu
 fu! unicode#Download(force) abort "{{{2
-    if (!filereadable(s:UniFile) || (getfsize(s:UniFile) == 0)) || a:force
+    if (!filereadable(s:data_file) || (getfsize(s:data_file) == 0)) || a:force
         if !a:force
-            call s:WarningMsg("File " . s:UniFile . " does not exist or is zero.")
+            call s:WarningMsg("File " . s:data_file . " does not exist or is zero.")
         else
-            call s:WarningMsg("Updating ". s:UniFile)
+            call s:WarningMsg("Updating ". s:data_file)
         endif
         call s:WarningMsg("Let's see, if we can download it.")
         call s:WarningMsg("If this doesn't work, you should download ")
-        call s:WarningMsg(s:unicode_URL . " and save it as " . s:UniFile)
+        call s:WarningMsg(s:unicode_URL . " and save it as " . s:data_file)
         let choice = confirm("Download " . s:unicode_URL . " now?", "&Yes\n&No", 1, "Question")
         if choice ==# 0 || choice ==# 2
             call s:WarningMsg("Not downloading file. You can retry by executing :UnicodeDownload")
@@ -109,20 +124,21 @@ fu! unicode#Download(force) abort "{{{2
         endif
         " remove cache file
         " (will be re-created later)
-        if filereadable(s:directory. '/UnicodeData.vim')
-            call delete(s:directory. '/UnicodeData.vim')
+        if filereadable(s:data_cache_file)
+            call delete(s:data_cache_file)
         endif
         if exists(":Nread")
+            if !<sid>MkDir(s:data_directory)
+                return 0
+            endif
             sp +enew
             " Use the default download method. You can specify a different
             " one, using :let g:netrw_http_cmd="wget"
-            if isdirectory(s:directory)
-                exe ":lcd " . s:directory
-            endif
+            exe ":lcd " . s:data_directory
             exe "0Nread " . s:unicode_URL
             $d _
-            exe ":noa :keepalt :sil w! " . s:UniFile
-            if getfsize(s:UniFile)==0
+            exe ":noa :keepalt :sil w! " . s:data_file
+            if getfsize(s:data_file)==0
                 call s:WarningMsg("Error fetching File from ". s:unicode_URL)
                 return 0
             endif
@@ -130,7 +146,7 @@ fu! unicode#Download(force) abort "{{{2
         else
             call s:WarningMsg("NetRw not loaded; cannot download file")
             call s:WarningMsg("Please download " . s:unicode_URL)
-            call s:WarningMsg("and save it as " . s:UniFile)
+            call s:WarningMsg("and save it as " . s:data_file)
             call s:WarningMsg("Quitting")
             return 0
         endif
@@ -139,16 +155,15 @@ fu! unicode#Download(force) abort "{{{2
 endfu
 fu! unicode#MkCache() abort "{{{2
     " Create the cache for existing Unicode Data file
-    let cache_file = s:directory. '/UnicodeData.vim'
-    if !filereadable(cache_file)
+    if !filereadable(s:data_cache_file)
         call <sid>UnicodeDict()
     else
         call <sid>WarningMsg("Cache already exists")
         return
     endif
-    if !filereadable(cache_file) ||
-        \ getftime(cache_file) < getftime(s:UniFile) ||
-        \ getfsize(cache_file) < 100 " Unicode Cache Dict should be a lot larger
+    if !filereadable(s:data_cache_file) ||
+        \ getftime(s:data_cache_file) < getftime(s:data_file) ||
+        \ getfsize(s:data_cache_file) < 100 " Unicode Cache Dict should be a lot larger
         call <sid>WarningMsg("Something went wrong when trying to create the cache file")
     else
         call <sid>WarningMsg("Cache successfully created")
@@ -274,7 +289,7 @@ fu! unicode#GetUniChar(...) abort "{{{2
             if empty(s:UniDict)
                 call add(msg,
                     \ printf("Can't determine char under cursor,".
-                    \ "%s not found", s:UniFile))
+                    \ "%s not found", s:data_file))
                 return
             endif
         endif
@@ -476,10 +491,9 @@ fu! unicode#GetDigraph(type, ...) abort "{{{2
 endfu
 fu! unicode#PrintUnicodeTable(force) abort "{{{2
     let buffer_name = 'UnicodeTable.txt'
-    let uni_table_file = s:directory. '/'. buffer_name
-    if filereadable(uni_table_file) && !a:force
+    if filereadable(s:table_cache_file) && !a:force
         call <sid>FindWindow(buffer_name)
-        exe 'noa :e' uni_table_file
+        exe 'noa :e' s:table_cache_file
         call <sid>Unitable_Afterload()
         return
     endif
@@ -505,7 +519,9 @@ fu! unicode#PrintUnicodeTable(force) abort "{{{2
     call setline(1, output)
     2,$sort x /^.\{,8}U+/
     setl nomodified
-    call writefile(getline(1,'$'), uni_table_file)
+    if <sid>MkDir(s:cache_directory)
+        call writefile(getline(1,'$'), s:table_cache_file)
+    endif
     call <sid>Unitable_Afterload()
 endfu
 fu! unicode#MkDigraphNew(arg) abort "{{{2
@@ -797,15 +813,14 @@ fu! <sid>UnicodeDict() abort "{{{2
     let dict={}
     " make sure unicodedata.txt is found
     if <sid>CheckDir()
-        let uni_cache_file = s:directory. '/UnicodeData.vim'
-        if filereadable(uni_cache_file) &&
-            \ getftime(uni_cache_file) >= getftime(s:UniFile) &&
-            \ getfsize(uni_cache_file) > 100 " Unicode Cache Dict should be a lot larger
-            exe "source" uni_cache_file
+        if filereadable(s:data_cache_file) &&
+            \ getftime(s:data_cache_file) >= getftime(s:data_file) &&
+            \ getfsize(s:data_cache_file) > 100 " Unicode Cache Dict should be a lot larger
+            exe "source" s:data_cache_file
             let dict=g:unicode#unicode#data
             unlet! g:unicode#unicode#data
         else
-            let list=readfile(s:UniFile)
+            let list=readfile(s:data_file)
             let ind = []
             for glyph in list
                 let val          = split(glyph, ";")
@@ -827,15 +842,21 @@ fu! <sid>UnicodeDict() abort "{{{2
     return dict
 endfu
 fu! <sid>CheckDir() abort "{{{2
+    if !<sid>MkDir(s:data_directory)
+        return 0
+    endif
+    return unicode#Download(0)
+endfu
+fu! <sid>MkDir(dir) abort "{{{2
     try
-        if (!isdirectory(s:directory))
-            call mkdir(s:directory)
+        if (!isdirectory(a:dir))
+            call mkdir(a:dir, 'p')
         endif
     catch
-        call s:WarningMsg("Error creating Directory: " . s:directory)
+        call s:WarningMsg("Error creating Directory: " . a:dir)
         return 0
     endtry
-    return unicode#Download(0)
+    return 1
 endfu
 fu! <sid>GetDigraphDict() abort "{{{2
     " returns a dict of digraphs 
@@ -929,6 +950,9 @@ fu! <sid>GetHtmlEntity(hex, all) abort "{{{2
     return html
 endfu
 fu! <sid>UnicodeWriteCache(data, ind) abort "{{{2
+    if !<sid>MkDir(s:cache_directory)
+        return
+    endif
     " Take unicode dictionary and write it in VimL form
     " so it will be faster to load
     let list = ['" internal cache file for unicode.vim plugin',
@@ -937,7 +961,7 @@ fu! <sid>UnicodeWriteCache(data, ind) abort "{{{2
         \ 'let unicode#unicode#data = {}']
     let format = "let unicode#unicode#data[0x%04X] = '%s'"
     let list += map(copy(a:ind), 'printf(format, v:val, a:data[v:val])')
-    call writefile(list, s:directory. '/UnicodeData.vim')
+    call writefile(list, s:data_cache_file)
     unlet! list
 endfu
 fu! <sid>GetUnicodeName(dec) abort "{{{2

--- a/doc/unicode.txt
+++ b/doc/unicode.txt
@@ -372,6 +372,12 @@ Key		Mode		Function
 
 To remap those mappings to different keys see below.
 
+                                              *g:Unicode_no_default_mappings*
+To prevent the unicode plugin from creating the above mappings define
+`g:Unicode_no_default_mappings` with a true-ish value in your vimrc like so: >
+
+    let g:Unicode_no_default_mappings = v:true
+<
                                                         *<Plug>(MakeDigraph)*
 The plugin sets up a map to <F4>, for easier generation of digraphs. This
 allows you to enter the digraph base characters and let the plugin convert a

--- a/doc/unicode.txt
+++ b/doc/unicode.txt
@@ -53,26 +53,44 @@ The unicode.vim Plugin uses the data available from the Unicode
 Consortium's website (http://www.unicode.org) to let you enter Unicode
 characters using a completion function.
 
-By default, the plugin creates a directory unicode below the path autoload
-where this plugin is located. Within this directory it will store  the file
-UnicodeData.txt from http://www.unicode.org/Public/UNIDATA/UnicodeData.txt
-(alternatively you can download it from
-ftp://ftp.unicode.org/Public/UNIDATA/UnicodeData.txt and place it manually
-below autoload/unicode/ from the plugins main directory.)
-which it will try to download using |netrw| . If this is unsuccessful, or
-you do not have |netrw| enabled, download the file manually and save it in the
-unicode directory below the autoload directory in which unicode.vim is
-located.
+By default the plugin stores the file UnicodeData.txt from
+http://www.unicode.org/Public/UNIDATA/UnicodeData.txt (alternatively you can
+download it from ftp://ftp.unicode.org/Public/UNIDATA/UnicodeData.txt)
+in the data directory. The plugin tries to download the file using |netrw|.
+If this is unsuccessful, or you do not have |netrw| enabled, download the file
+manually and save it in the data directory.
+
+                         *unicode-data-directory* *unicode-cache-directory*
+If you run Neovim, then the data and cache directory are XDG Base Directory
+Specification compliant. In this case the data and cache directories are
+`stdpath("data") . "/site/unicode"` and `stdpath("cache") . "/unicode"`,
+respectively (see |stdpath()|).
+
+If not running Neovim, then the data directory is the same as the cache
+directory, which is the "unicode" directory below the autoload directory in
+which unicode.vim is located. So if you have installed unicode.vim into
+"/home/user/.vim", then the data and cache directory should be
+"/home/user/.vim/autoload/unicode".
+
+                     *g:Unicode_data_directory* *g:Unicode_cache_directory*
+The cache and data directory can also specified using the variables
+`g:Unicode_data_directory` and `g:Unicode_cache_directory` like so: >
+
+    let g:Unicode_data_directory = /home/user/data/
+    let g:Unicode_cache_directory = /tmp/
+<
+If the cache or data directory does not exist, it is created on the first use
+(together with any necessary intermediate directories).
+
+After the plugin has been first used, it automatically creates some cache
+files (see |:UnicodeCache| and |:UnicodeTable|), which can be safely removed,
+they will be recreated the next time this plugin is used.
+
                                                      *unicode-plugin-error*
 If the plugin gives an error or does not complete anything, first check, that
 UnicodeData.txt from the Unicode Consortium has been successfully downloaded.
-It should be located below the autoload/unicode.vim script in a directory
-called unicode. So if you have installed unicode.vim into
-/home/user/.vim, UnicodeData.txt should be located at:
-/home/user/.vim/autoload/unicode/UnicodeData.txt (after the plugin has been
-first used, it automatically creates a cache file |:UnicodeCache| of that data
-in the same directory called UnicodeData.vim, which can be safely removed, it
-will be recreated the next time this plugin is used) and should look like this:
+It should be located in the data directory (see |unicode-data-directory|) and
+should look like this:
 
 0020;SPACE;Zs;0;WS;;;;;N;;;;;
 0021;EXCLAMATION MARK;Po;0;ON;;;;;N;;;;;
@@ -174,8 +192,9 @@ at the current cursor position (only when your buffer is writable).
     :UnicodeTable[!]
 
 Creates a new window with a table of all Unicode characters. For performance
-reasons, the table will be cached and stored locally in the install directory.
-That makes loading the table after the initial run much faster. If you want to
+reasons, the table will be cached and stored locally in the cache directory
+(see |unicode-cache-directory|) under the name "UnicodeTable.txt". That makes
+loading the table after the initial run much faster. If you want to
 re-generate the table from scratch (and discarding the cache file), use the
 "!" attribute.
 
@@ -184,6 +203,8 @@ re-generate the table from scratch (and discarding the cache file), use the
     :UnicodeDownload
 
 Downloads the Unicode data. Can also be used to update the local data file.
+The downloaded file is stored as "UnicodeData.txt" in the data directory (see
+|unicode-data-directory|).
 
 							    *:DigraphNew*
 >
@@ -237,10 +258,12 @@ U+01F6 LATIN CAPITAL LETTER HWAIR!
 >
     :UnicodeCache
 
-Manually re-creates the cache file from the UnicodeData.txt file. Should
+Manually re-creates the cache file from the "UnicodeData.txt" file. Should
 normally not be needed to be executed manually, as the plugin does this for
 you. Might be necessary if you want to distribute the plugin on a read-only
-filesystem to set up everything before first using it.
+filesystem to set up everything before first using it. The cache file is named
+"UnicodeData.vim" and stored in the cache directory (see
+|unicode-cache-directory|).
 
 ==============================================================================
 3. Completions

--- a/doc/unicode.txt
+++ b/doc/unicode.txt
@@ -82,9 +82,17 @@ The cache and data directory can also specified using the variables
 If the cache or data directory does not exist, it is created on the first use
 (together with any necessary intermediate directories).
 
+                                                      *g:Unicode_use_cache*
 After the plugin has been first used, it automatically creates some cache
 files (see |:UnicodeCache| and |:UnicodeTable|), which can be safely removed,
-they will be recreated the next time this plugin is used.
+they will be recreated the next time this plugin is used. To prevent the
+plugin from creating any cache files or the cache directory, define the
+variable `g:Unicode_use_cache` with a false-ish value, e.g. >
+
+    let g:Unicode_use_cache = v:false
+<
+Note that setting this varibale does not delete any previously generated cache
+files, those have to be removed by hand.
 
                                                      *unicode-plugin-error*
 If the plugin gives an error or does not complete anything, first check, that

--- a/plugin/unicode.vim
+++ b/plugin/unicode.vim
@@ -53,33 +53,35 @@ inoremap <unique><script><silent> <Plug>(UnicodeComplete)   <C-R>=unicode#Comple
 inoremap <unique><script><silent> <Plug>(HTMLEntityComplete)   <C-R>=unicode#CompleteHTMLEntity()<CR>
 nnoremap <unique><script><silent> <Plug>(UnicodeSwapCompleteName) :<C-U>call <sid>ToggleUnicodeCompletion()<CR>
 
-if !hasmapto('<Plug>(MakeDigraph)', 'n') && maparg('<f4>', 'n') ==# ''
-    nmap <F4> <Plug>(MakeDigraph)
-endif
+if !(exists("g:Unicode_no_default_mappings") && g:Unicode_no_default_mappings)
+    if !hasmapto('<Plug>(MakeDigraph)', 'n') && maparg('<f4>', 'n') ==# ''
+        nmap <F4> <Plug>(MakeDigraph)
+    endif
 
-if !hasmapto('<Plug>(MakeDigraph)', 'v') && maparg('<f4>', 'v') ==# ''
-    vmap <F4> <Plug>(MakeDigraph)
-endif
+    if !hasmapto('<Plug>(MakeDigraph)', 'v') && maparg('<f4>', 'v') ==# ''
+        vmap <F4> <Plug>(MakeDigraph)
+    endif
 
-if !hasmapto('<Plug>(DigraphComplete)', 'i') && maparg('<c-x><c-g>', 'i') ==# ''
-    imap <C-X><C-G> <Plug>(DigraphComplete)
-endif
+    if !hasmapto('<Plug>(DigraphComplete)', 'i') && maparg('<c-x><c-g>', 'i') ==# ''
+        imap <C-X><C-G> <Plug>(DigraphComplete)
+    endif
 
-if !hasmapto('<Plug>(UnicodeComplete)', 'i') && maparg('<c-x><c-z>', 'i') ==# ''
-    imap <C-X><C-Z> <Plug>(UnicodeComplete)
-endif
+    if !hasmapto('<Plug>(UnicodeComplete)', 'i') && maparg('<c-x><c-z>', 'i') ==# ''
+        imap <C-X><C-Z> <Plug>(UnicodeComplete)
+    endif
 
-if !hasmapto('<Plug>(HTMLEntityComplete)', 'i') && maparg('<c-x><c-b>', 'i') ==# ''
-    imap <C-X><C-B> <Plug>(HTMLEntityComplete)
-endif
+    if !hasmapto('<Plug>(HTMLEntityComplete)', 'i') && maparg('<c-x><c-b>', 'i') ==# ''
+        imap <C-X><C-B> <Plug>(HTMLEntityComplete)
+    endif
 
-if !hasmapto('<Plug>(UnicodeSwapCompleteName)', 'n') && maparg('<leader>un', 'n') ==# ''
-    nmap <leader>un <Plug>(UnicodeSwapCompleteName)
-endif
+    if !hasmapto('<Plug>(UnicodeSwapCompleteName)', 'n') && maparg('<leader>un', 'n') ==# ''
+        nmap <leader>un <Plug>(UnicodeSwapCompleteName)
+    endif
 
-"if !hasmapto('<Plug>(UnicodeGA)')
-"    nmap ga <Plug>(UnicodeGA)
-"endif
+"    if !hasmapto('<Plug>(UnicodeGA)')
+"        nmap ga <Plug>(UnicodeGA)
+"    endif
+endif
 
 " =====================================================================
 " Restoration And Modelines: {{{1


### PR DESCRIPTION
Dear Christian

I'd like your plugin very much. Thanks for writing it. However, there were some itches which annoyed mid, which I scratched and now want to share it. This pull request is in essence for pull requests as each commit is self-contained (except for the last one which builds on the previous one). If you don't like one, please still consider the others.

The commits are:

### Allow disabling the default mappings

While you already make quite the effort to not override mappings defined previously by the user. It is currently not possible to suppress the creation of a mapping for an unbound key. This commit introduces (and documents) a variable `g:Unicode_no_default_mappings`, which if set to something true-ish prevents the creation of all mappings to keys (but not the `<Plug>(...)` ones.
User setting this can be considered such advanced that they now how to set up their own mappings, thus this is not explained further.

### Ask before downloading

Call me old fashioned, but I don't like it when programs download something behind my back without asking me first. In this situation it is the UnicodeData.txt file. The plugin did wait 5secs before doing so but gives no indication what it does. (On my first use I assumed it was already downloading.) This commit changes this and replaces the 5sec sleep with an explicit question to the user, whether to download it from the web or not.

### Introduce data and cache directory

I personally don't like it when my code directory is clobbered with data files (like UnicodeData.txt).
This commit introduces two directories the data directory and the cache directory. (If you now think XDG Base Directory Specification, then you are not mistaken since this was the inspiration.)

By default, these directories are the same and the old `autoload/unicode/` directory. If, however, it is detected that Neovim is used, then they are set to the default XDG compliant directories (if nothing else set these are `~/.local/share/nvim/site/unicode/` and `~/.cache/nvim/unicode/`).

Remarks on the `site` in the data directory path: I included site here since I mimicked the data spell file which under Neovim can be found in `~/.local/share/nvim/site/spell/`. If you don't like that, feel free to edit the one line in `autoload/unicode.vim` which it contains.

The same commit also defines two config variables, which allow the user to set the path for data and cache directory explicitly. Might come in handy for people with a read-only file system.

Implications for users: For new users, this should match more the expectations they have, i.e. Neovim users expect XDG compliance, while others do not. Current users, however, have a one-time small inconvenience when running Neovim. They either have to redownload the file (or move it on their file system to the expected location). Or have to set one of the new `g:Unicode_*_directory` variables. Since this is again a one-time thing. I consider this not being a blocker.

### Disable caching mechanism

This thing was just easy to implement (and one person requested it on the bug tracker). It introduces the variable `g:Unicode_use_cache`, which if set to false, disables the usage of the cache directory and cache files entirely. Said variable is not defined by default, which means "use the cache" and is the current status quo.

Regards
Emory
