### PR TITLE
Add multiple selection to fuzzy name search.

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -181,8 +181,8 @@ fu! unicode#Fuzzy() abort "{{{2
     if !exists('s:fuzzy_source') | call s:set_fuzzy_source() | endif
     call fzf#run(fzf#wrap({
         \ 'source': s:fuzzy_source,
-        \ 'options': '--ansi --nth=2.. --tiebreak=index +m',
-        \ 'sink': function('s:inject_unicode_character'
+        \ 'options': '--ansi --nth=2.. --tiebreak=index -m',
+        \ 'sink*': function('s:inject_unicode_characters'
         \ )}))
 endfu
 " internal functions {{{1
@@ -1073,9 +1073,19 @@ fu! <sid>translate(lists) abort "{{{2
     endfor
     return a:lists
 endfu
-fu! <sid>inject_unicode_character(line) abort "{{{2
-    let char = matchstr(a:line, '^.')
-    call feedkeys((col('.') >= col('$') - 1 ? 'a' : 'i') . char, 'in')
+fu! <sid>inject_unicode_characters(lines) abort "{{{2
+    let chars = ''
+    try
+        for line in a:lines
+            try
+                let chars .= matchstr(line, '^.')
+            catch /^Vim:Interrupt$/
+                break
+            endtry
+        endfor
+    finally
+        call feedkeys(chars, 'in')
+    endtry
 endfu
 fu! <sid>set_fuzzy_source() abort "{{{2
     if !filereadable(s:data_cache_file) | exe 'UnicodeCache' | endif

--- a/doc/unicode.txt
+++ b/doc/unicode.txt
@@ -402,7 +402,7 @@ CTRL-X CTRL-B           Search for the characters in front of the cursor and
 --------------------------------------------------
 
 CTRL-G CTRL-F           Invoke fzf to fuzzy search through all unicode names.
-                        The chosen match is inserted.
+                        The chosen matches are inserted.
 
 ==============================================================================
 4. Mappings						*unicode-mappings*
@@ -466,8 +466,11 @@ unicode names. Use the <Plug>(UnicodeSwapCompleteName) to toggle between both
 completion types. By default, this is mapped to <Leader>un
 
 					               *<Plug>(UnicodeFuzzy)*
-Insert a unicode character after performing a fuzzy search in all unicode names.
-By default, this is mapped to <C-G><C-F>
+Insert some unicode characters after performing a fuzzy search in all unicode
+names.  To insert a single match from the fzf search results select the match
+and press <ENTER>.  To insert multiple matches press <TAB> on each chosen
+match then press <ENTER> to complete the insertion.
+By default, this is mapped to <C-G><C-F> in insert mode only.
 Requires fzf: https://github.com/junegunn/fzf
 ==============================================================================
 5. Public functions					*unicode-functions*


### PR DESCRIPTION
Take advantage of fzf's built-in multiple selection window to
insert more than one character from the same search result set.

Also do not inject spurious 'a' or 'i' character.

---

This commit extends #40 as far as fzf integration.
It also fixes an issue about #40, which inserted a spurious 'a' or 'i' before the unicode character.   I think that happened because the code assumed normal mode, so pushed 'a' or 'i' before the unicode character to enter insert mode. However <c-g><c-f> is bound with an imap so there is no need to push 'a' or 'i'.  Hopefully I didn't misunderstand the original intent.
This commit was tested on Linux only.