### PR TITLE
avoid E325 when ":UnicodeTable" is run in 2 Vim instances (follow-up)

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -606,9 +606,9 @@ fu! <sid>FindWindow(name) abort "{{{2
     let winname = a:name
     let win = bufwinnr('^'.winname.'$')
     if win != -1
-        exe 'noa ' .win. 'wincmd w'
+        exe 'noa nos ' .win. 'wincmd w'
     else
-        exe  'noa sp' winname
+        exe  'noa nos sp' winname
     endif
 endfu
 fu! <sid>AddCompleteEntries(dict) abort "{{{2


### PR DESCRIPTION
This PR tries to avoid `E325` when `:UnicodeTable` is run from several Vim instances. I already sent a PR for the same issue (#41), but it only took care of the case where the command was run during Vim's startup. It seems the issue persists when the command is run *after* the startup, because I can still reproduce the issue in this case.
