### PR TITLE
Fix 'cpo' restoration when :UnicodeTable is executed twice

### DIFF
--- a/plugin/unicode.vim
+++ b/plugin/unicode.vim
@@ -37,7 +37,7 @@ com! -nargs=? -bang Digraphs	    call unicode#PrintDigraphs(<q-args>, <q-bang>)
 " deprecated
 com! -nargs=1       SearchUnicode   call unicode#PrintUnicode(<q-args>, '')
 com! -nargs=1 -bang UnicodeSearch   call unicode#PrintUnicode(<q-args>, <q-bang>=='!')
-com! -bang		      UnicodeTable    call unicode#PrintUnicodeTable(<q-bang>=='!')
+com! -bang -bar     UnicodeTable    call unicode#PrintUnicodeTable(<q-bang>=='!')
 com! -nargs=1       DigraphNew	    call unicode#MkDigraphNew(<f-args>)
 com!                UnicodeCache    call unicode#MkCache()
 " deprecated

--- a/syntax/unicode.vim
+++ b/syntax/unicode.vim
@@ -6,6 +6,8 @@ scriptencoding utf8
 if version < 600
     syn clear
 elseif exists("b:current_syntax")
+    let &cpo = s:cpo_save
+    unlet s:cpo_save
     finish
 endif
 


### PR DESCRIPTION
After executing `:UnicodeTable` twice, `'cpoptions'` is reset to its default Vim value.

To reproduce, run this shell command:

    vim -Nu <(cat <<'EOF'
        vim9
        set rtp-=~/.vim
        set rtp-=~/.vim/after
        set rtp^=~/.vim/plugged/unicode.vim/
        set cpo=aABceFsMny>
        syntax enable
        au VimEnter * Func()
        def Func()
            sil UnicodeTable
            q
            echom "&cpo BEFORE :UnicodeTable is run a second time: " .. &cpo
            sil UnicodeTable
            echom "&cpo AFTER :UnicodeTable is run a second time: " .. &cpo
        enddef
    EOF
    )

*You might need to adapt the path to the plugin in the last "set rtp" command.*

Then, execute `:mess`.

Expected output:

    &cpo BEFORE :UnicodeTable is run a second time: aABceFsMny>
    &cpo AFTER :UnicodeTable is run a second time: aABceFsMny>

Actual output:

    &cpo BEFORE :UnicodeTable is run a second time: aABceFsMny>
    &cpo AFTER :UnicodeTable is run a second time: aABceFs

The issue comes from the syntax plugin which might bail out without restoring `'cpoptions'` properly.

This PR tries to fix this issue by restoring `'cpoptions'` before bailing out early.

---

Also, `:UnicodeTable` is not defined with `-bar`, which means we can't execute something like this:

    :UnicodeTable | other command

To fix this, the PR adds the `-bar` attribute to the command.
