### PR TITLE
make sure the prompt from "confirm()" is visible

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -121,7 +121,12 @@ fu! unicode#Download(force) abort "{{{2
         call s:WarningMsg("Let's see, if we can download it.")
         call s:WarningMsg("If this doesn't work, you should download ")
         call s:WarningMsg(s:unicode_URL . " and save it as " . s:data_file)
-        let choice = confirm("Download " . s:unicode_URL . " now?", "&Yes\n&No", 1, "Question")
+        let args = ["Download " . s:unicode_URL . " now?", "&Yes\n&No", 1, "Question"]
+        if exists(':unsilent') == 2
+            unsilent let choice = call('confirm', args)
+        else
+            let choice = call('confirm', args)
+        endif
         if choice ==# 0 || choice ==# 2
             call s:WarningMsg("Not downloading file. You can retry by executing :UnicodeDownload")
             return 0


### PR DESCRIPTION
If the user invokes a command from the plugin silently, they might miss the prompt from `confirm()` which is not displayed then.

To reproduce:

    vim -Nu NONE -S <(cat <<'EOF'
        vim9script
        set pp=/tmp/.vim rtp=/tmp/.vim
        delete('/tmp/.vim', 'rf')
        mkdir('/tmp/.vim/pack/unicode/opt/unicode.vim', 'p')
        system('git clone https://github.com/chrisbra/unicode.vim /tmp/.vim/pack/unicode/opt/unicode.vim')
        packadd unicode.vim
        var out: string = execute('UnicodeName')
    EOF
    )

Notice that the 4 messages from `s:WarningMsg()` are correctly displayed, but not the `confirm()` prompt.

https://github.com/chrisbra/unicode.vim/blob/8b6bb82f66c1f336257e670eb9b7c03f29df3345/autoload/unicode.vim#L124

That's because `execute()` is silent by default.

One solution would be to use `:unsilent`, just like in `s:WarningMsg()`.
