### PR TITLE
fix highlighting after executing ":Digraphs!"

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -1024,6 +1024,7 @@ fu! <sid>ScreenOutput(...) abort "{{{2
         endif
         let i+=1
     endfor
+    echohl NONE
 endfu
 fu! <sid>WarningMsg(msg) abort "{{{2
     echohl WarningMsg


### PR DESCRIPTION
After executing `:Digraphs!`, Vim unexpectedly highlights echo'ed messages with the highlighting group `Title`.

To reproduce, run this shell command:

    vim -Nu NONE -S <(cat <<'EOF'
        vim9script
        set pp=/tmp/.vim rtp=/tmp/.vim
        delete('/tmp/.vim', 'rf')
        mkdir('/tmp/.vim/pack/unicode/opt/unicode.vim', 'p')
        system('git clone https://github.com/chrisbra/unicode.vim /tmp/.vim/pack/unicode/opt/unicode.vim')
        packadd unicode.vim
        Digraphs!
    EOF
    )

Press `y` to download the missing file.
Press `G` to jump at the end of the pager.
Finally, run:

    :echo 'TEST'

`TEST` is highlighted with the `Title` highlighting group.

I think the solution is to run `:echohl NONE` at the end of the `ScreenOutput()` function.

