### PR TITLE
Fix :Digraphs filtering with single-letter

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -434,7 +434,7 @@ fu! unicode#PrintDigraphs(match, bang) abort "{{{2
     " outputs only first digraph that exists for char
     " makes a difference for e.g. Euro which has (=e Eu)
     let match    = '\V'.escape(a:match, '\\')
-    let digraphs = <sid>DigraphsInternal(match)
+    let digraphs = <sid>DigraphsInternal(a:match)
     let s:output_width=1
 
     for item in digraphs
@@ -746,7 +746,7 @@ fu! <sid>DigraphsInternal(match) abort "{{{2
     let unidict = {}
     let cnt = 0
     let did_verbose = 0
-    if (len(a:match > 1 && digit == 0))
+    if (len(a:match) > 1 && digit == 0)
         " try to match digest name from unicode name
         if !exists("s:UniDict")
             let s:UniDict = <sid>UnicodeDict()

--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -742,6 +742,7 @@ fu! <sid>DigraphsInternal(match) abort "{{{2
     " Returns a list of digraphs matching a:match
     let outlist = []
     let digit = a:match + 0
+    let match = '\V'.escape(a:match, '\\')
     let name = ''
     let unidict = {}
     let cnt = 0
@@ -768,7 +769,7 @@ fu! <sid>DigraphsInternal(match) abort "{{{2
         " could be a list of 1 or 2 matchings chars,
         " e.g.
         " {'8364': ['=e € 8364','Eu € 8364']}
-        if match(dig, a:match) == -1  && digit == 0 && empty(unidict)
+        if match(dig, match) == -1  && digit == 0 && empty(unidict)
             continue
         endif
         " digraph: xy Z \d\+


### PR DESCRIPTION
If the argument of the :Digraphs command was a single letter, the
filtering wasn't working properly.

Help [says](https://github.com/chrisbra/unicode.vim/blob/62f7a3558ee4402bcaaae8638e768268f1137a0f/doc/unicode.txt#L170):

```
    :Digraphs! A

displays all digraphs, that match 'A' (e.g. all that can be created with the
letter A or whose digraph matches the letter 'A'.)
```

but it would just filter against the whole digraph name, not just the characters combination (as if the entered match was >1 letter).