### PR TITLE
Trim User's Number Input

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -69,7 +69,7 @@ fu! unicode#Search(match) abort "{{{2
         endfor
         echon "\n"
         unlet! s:color_pattern
-        let input=input('Please choose: ')
+        let input=trim(input('Please choose: '))
         if empty(input)
             return
         elseif input !~? '^\d\+' || input > len(uni)
@@ -470,7 +470,7 @@ fu! unicode#PrintUnicode(match, bang) abort "{{{2
     endfor
     unlet! s:color_pattern
     if !&l:ro && &l:ma && a:bang
-        let input=input('Enter number of char to insert: ')
+        let input=trim(input('Enter number of char to insert: '))
         if empty(input)
             return
         elseif input !~? '^\d\+' || input > len(uni)


### PR DESCRIPTION
When paging through a long list of `:UnicodeSearch!` results, I sometimes forget to erase the extra spaces that end up in my answer to the **'Enter number of char to insert:'** prompt. Thus, my answer ends up becoming something like `" 42"`, which doesn't match the `^\d\+` pattern, and is rejected. 

I found the same thing happening in the `unicode#Search()` function.

This commit trims the user input so that the regex match is successful.