### PR TITLE
Allow entering multiple numbers when using :UnicodeSearch!

### DIFF
--- a/autoload/unicode.vim
+++ b/autoload/unicode.vim
@@ -458,8 +458,8 @@ fu! unicode#PrintUnicode(match, bang) abort "{{{2
     for item in uni
         let dig  = get(item, 'dig' , '')
         let html = get(item, 'html', '')
-            let width=strlen(len(uni))
-            call <sid>ScreenOutput( (a:bang ? printf("%*i", width, cnt) : ''),
+        let width=strlen(len(uni))
+        call <sid>ScreenOutput( (a:bang ? printf("%*i", width, cnt) : ''),
                 \ printf(format[0], item.glyph),
                 \ printf(format[1].format[2], item.dec, item.dec, item.name),
                 \ (empty(dig)  ? [] : printf(" %s", dig)),
@@ -470,13 +470,21 @@ fu! unicode#PrintUnicode(match, bang) abort "{{{2
     endfor
     unlet! s:color_pattern
     if !&l:ro && &l:ma && a:bang
-        let input=trim(input('Enter number of char to insert: '))
-        if empty(input)
-            return
-        elseif input !~? '^\d\+' || input > len(uni)
-            echo "\ninvalid number selected, aborting..."
-        else
-            exe "norm! a". (uni[input-1].glyph). "\<esc>"
+        let input=trim(input('Enter one or more numbers of character(s) to insert: '))
+        let result = ''
+        let rejected = []
+        for num in split(input, '\m\D\+')
+            if num <= 0 || num > len(uni)
+                call add(rejected,num)
+            else
+                let result .= uni[num-1].glyph
+            endif
+        endfor
+        if !empty(rejected)
+            echo "\ninvalid numbers skipped: " . join(rejected,", ")
+        endif
+        if !empty(result)
+            exe "norm! a". result. "\<esc>"
         endif
     endif
 endfu

--- a/doc/unicode.txt
+++ b/doc/unicode.txt
@@ -206,8 +206,11 @@ being ignored.) If possible, digraphs chars are displayed in (), separated by
 commas and html entities are displayed as well. Note, depending on your
 search term, this might be a little bit slow.
 
-You can use the bang "!" attribute, it will prompt you, which item to insert
-at the current cursor position (only when your buffer is writable).
+If you use the bang "!" attribute, it will prompt you for one or more numbers
+of characters to insert. The numbers can be delimited by anything that is not
+a digit. Valid corresponding characters are inserted into the buffer at the
+current cursor position (only when your buffer is writable).
+
 							    *:UnicodeTable*
 >
     :UnicodeTable[!]


### PR DESCRIPTION
When using `:UnicodeSearch!` to search for and insert many related characters, it would be handy to be able to insert them all at once if they appear in the same search. For example, if you wanted to insert a bunch of Greek letters, you could use this search:

```vim
:UnicodeSearch! greek capital letter \S\+$
```

Or to insert a bunch of double-line box drawing characters, use this search:

```vim
:UnicodeSearch! box.*double
```

Both of these searches return a short list, and if you could insert all the characters you need at once, instead of repeating the search over and over, much time could be saved. That's where this pull request comes in. After displaying the search results, the function now will prompt for, and accept, multiple numbers, delimited by any non-digit character. Each number is compared against the size of the search results list, and if in range, the corresponding character is inserted into the current buffer.

While the `unicode#Search()` function prompts the user similarly, it was left alone as it serves a different purpose: returning the decimal code of the character to the calling function.
